### PR TITLE
:rocket: feat(Panels-and-aliquots): Add breast milk processing to lab profiles

### DIFF
--- a/flourish_labs/aliquot_types.py
+++ b/flourish_labs/aliquot_types.py
@@ -20,4 +20,4 @@ lithium_heparin = AliquotType('Lithium Heparin', alpha_code='IGRA', numeric_code
 
 breast_milk = AliquotType('Breast Milk', alpha_code='BM', numeric_code='15')
 
-wb.add_derivatives(bc, pl, wb, pbmc, serum, lithium_heparin, breast_milk)
+wb.add_derivatives(bc, pl, wb, pbmc, serum, lithium_heparin)

--- a/flourish_labs/aliquot_types.py
+++ b/flourish_labs/aliquot_types.py
@@ -18,4 +18,6 @@ serum = AliquotType(name='Serum', alpha_code='SERUM', numeric_code='06')
 
 lithium_heparin = AliquotType('Lithium Heparin', alpha_code='IGRA', numeric_code='06')
 
-wb.add_derivatives(bc, pl, wb, pbmc, serum, lithium_heparin)
+breast_milk = AliquotType('Breast Milk', alpha_code='BM', numeric_code='15')
+
+wb.add_derivatives(bc, pl, wb, pbmc, serum, lithium_heparin, breast_milk)

--- a/flourish_labs/caregiver_panels.py
+++ b/flourish_labs/caregiver_panels.py
@@ -1,9 +1,10 @@
-from edc_lab import RequisitionPanel, LabProfile
+from edc_lab import LabProfile, RequisitionPanel
 from edc_lab.site_labs import site_labs
 
-from .aliquot_types import wb
-from .processing_profiles import cbc_processing
-from .processing_profiles import viral_load_processing, cd4_processing, hematology_processing
+from .aliquot_types import breast_milk, wb
+from .processing_profiles import breast_milk_processing, cbc_processing
+from .processing_profiles import cd4_processing, hematology_processing, \
+    viral_load_processing
 
 caregiver_lab_profile = LabProfile(
     name='flourish_caregiver_lab_profile',
@@ -33,9 +34,16 @@ cbc_panel = RequisitionPanel(
     aliquot_type=wb,
     processing_profile=cbc_processing)
 
+breast_milk_panel = RequisitionPanel(
+    name='breast_milk',
+    verbose_name='Breast Milk',
+    aliquot_type=breast_milk,
+    processing_profile=breast_milk_processing)
+
 caregiver_lab_profile.add_panel(viral_load_panel)
 caregiver_lab_profile.add_panel(cd4_panel)
 caregiver_lab_profile.add_panel(hematology_panel)
 caregiver_lab_profile.add_panel(cbc_panel)
+caregiver_lab_profile.add_panel(breast_milk_panel)
 
-site_labs.register(caregiver_lab_profile,)
+site_labs.register(caregiver_lab_profile, )

--- a/flourish_labs/processing_profiles.py
+++ b/flourish_labs/processing_profiles.py
@@ -1,6 +1,7 @@
 from edc_lab import Process, ProcessingProfile
 
-from .aliquot_types import wb, pl, bc, dna_pcr, ss, pbmc, rs, serum, lithium_heparin
+from .aliquot_types import breast_milk, wb, pl, bc, dna_pcr, ss, pbmc, rs, serum, \
+    lithium_heparin
 
 viral_load_processing = ProcessingProfile(name='viral_load', aliquot_type=wb)
 vl_pl_process = Process(aliquot_type=pl, aliquot_count=3)
@@ -18,6 +19,8 @@ dna_pcr_processing = ProcessingProfile(name='dna_pcr', aliquot_type=dna_pcr)
 stool_sample_processing = ProcessingProfile(name='stool_sample', aliquot_type=ss)
 
 rectal_swab_processing = ProcessingProfile(name='rectal_swab', aliquot_type=rs)
+
+breast_milk_processing = ProcessingProfile(name='breast_milk', aliquot_type=breast_milk)
 
 
 infant_plasma_cykotines_processing = ProcessingProfile(


### PR DESCRIPTION
Introduced a new aliquot type "Breast Milk" and added it to various processing profiles, including the caregiver lab profile. This required adding the `breast_milk` component in multiple scripts, such as `processing_profiles.py`, `aliquot_types.py`, and `caregiver_panels.py`. The corresponding panel 'breast_milk_panel' has also been registered in the `caregiver_lab_profile`.